### PR TITLE
Adds alignment modifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: node_js
 node_js:
   - "4"
 
-branches:
-  only:
-    - master
-
 cache:
   directories:
     - node_modules

--- a/README.md
+++ b/README.md
@@ -49,4 +49,11 @@ The following variables can be found in `_config.scss`
 // Namespaces
 $seed-control-group-namespace: "o-control-group" !default;
 $seed-control-group-block-namespace: "#{$seed-control-group-namespace}__block" !default;
+
+// Alignment
+$seed-control-group-alignment: (
+  left: flex-start,
+  center: center,
+  right: flex-end,
+) !default;
 ```

--- a/dist/seed-control-group.css
+++ b/dist/seed-control-group.css
@@ -1,5 +1,5 @@
 /**
- * seed-control-group v0.0.4
+ * seed-control-group v0.0.5
  * Control group object pack for Seed
  * Licensed under MIT
  */

--- a/dist/seed-control-group.min.css
+++ b/dist/seed-control-group.min.css
@@ -1,5 +1,5 @@
 /**
- * seed-control-group v0.0.4
+ * seed-control-group v0.0.5
  * Control group object pack for Seed
  * Licensed under MIT
  */

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "banner": "node ./scripts/banner.js",
     "build": "npm run build:main && npm run banner",
     "build:main": "node ./scripts/build.js",
-    "test:mocha": "mocha",
+    "test:mocha": "./node_modules/.bin/mocha",
     "test": "npm run test:mocha",
     "prepublish": "npm run test"
   },

--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
     "node": ">=4"
   },
   "devDependencies": {
+    "chai": "3.5.0",
     "mkdirp": "^0.5.1",
     "mocha": "3.2.0",
     "node-sass": "^3.10.1",
-    "seed-bistro": "0.0.2"
+    "seed-barista": "0.2.1"
   },
   "dependencies": {
     "sass-pathfinder": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "banner": "node ./scripts/banner.js",
     "build": "npm run build:main && npm run banner",
     "build:main": "node ./scripts/build.js",
-    "test": "npm run build",
+    "test:mocha": "mocha",
+    "test": "npm run test:mocha",
     "prepublish": "npm run test"
   },
   "repository": {
@@ -40,11 +41,13 @@
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",
-    "node-sass": "^3.10.1"
+    "node-sass": "^3.10.1",
+    "seed-bistro": "0.0.2"
   },
   "dependencies": {
     "sass-pathfinder": "0.0.5",
     "seed-border": "0.0.8",
+    "seed-breakpoints": "0.4.0",
     "seed-publish": "0.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "banner": "node ./scripts/banner.js",
     "build": "npm run build:main && npm run banner",
     "build:main": "node ./scripts/build.js",
-    "test:mocha": "./node_modules/.bin/mocha",
+    "test:mocha": "mocha",
     "test": "npm run test:mocha",
     "prepublish": "npm run test"
   },
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",
+    "mocha": "3.2.0",
     "node-sass": "^3.10.1",
     "seed-bistro": "0.0.2"
   },

--- a/scss/pack/seed-control-group/_config.scss
+++ b/scss/pack/seed-control-group/_config.scss
@@ -3,3 +3,10 @@
 // Namespaces
 $seed-control-group-namespace: "o-control-group" !default;
 $seed-control-group-block-namespace: "#{$seed-control-group-namespace}__block" !default;
+
+// Alignment
+$seed-control-group-alignment: (
+  left: flex-start,
+  center: center,
+  right: flex-end,
+) !default;

--- a/scss/pack/seed-control-group/objects/_control-group.scss
+++ b/scss/pack/seed-control-group/objects/_control-group.scss
@@ -1,6 +1,7 @@
 // Objects :: Control Group
 
 // Dependencies
+@import "pack/seed-breakpoints/_index";
 @import "pack/seed-border/config";
 @import "pack/seed-publish/_index";
 @import "../config";
@@ -58,6 +59,14 @@
     &--block {
       > * {
         flex: 1;
+      }
+    }
+
+    // Modifiers: Alignment
+    $mod: "-";
+    &#{$mod} {
+      @include breakpoint-prop-map($seed-control-group-alignment, (prop)) {
+        justify-content: prop(prop);
       }
     }
   }

--- a/test/_build.js
+++ b/test/_build.js
@@ -1,0 +1,19 @@
+// Test :: Build
+/* globals describe: true, it: true */
+'use strict';
+
+var assert = require('chai').assert;
+var barista = require('seed-barista');
+
+describe('seed-control-group: config', function() {
+  var style = `
+    @import "./_index";
+  `;
+  var output = barista({ content: style });
+
+  it('should build', function() {
+    var $o = output.$('.o-control-group');
+
+    assert.isOk($o.selectors.length);
+  });
+});

--- a/test/modifiers.js
+++ b/test/modifiers.js
@@ -1,0 +1,65 @@
+// Test :: Modifiers
+/* globals describe: true, it: true */
+'use strict';
+
+var assert = require('chai').assert;
+var barista = require('seed-barista');
+
+describe('seed-control-group: modifiers', function() {
+
+  describe('block', function() {
+    var style = `
+      @import "./_index";
+    `;
+    var output = barista({ content: style });
+
+    it('should have the block modifier', function() {
+      var $o = output.$('.o-control-group--block > *');
+
+      assert.isOk($o.selectors.length);
+    });
+  });
+
+  describe('left', function() {
+    var style = `
+      @import "./_index";
+    `;
+    var output = barista({ content: style });
+
+    it('should have the alignment modifier', function() {
+      var $o = output.$('.o-control-group--left');
+
+      assert.isOk($o.selectors.length);
+      assert.equal($o.getProp('justify-content'), 'flex-start');
+    });
+  });
+
+  describe('center', function() {
+    var style = `
+      @import "./_index";
+    `;
+    var output = barista({ content: style });
+
+    it('should have the alignment modifier', function() {
+      var $o = output.$('.o-control-group--center');
+
+      assert.isOk($o.selectors.length);
+      assert.equal($o.getProp('justify-content'), 'center');
+    });
+  });
+
+  describe('right', function() {
+    var style = `
+      @import "./_index";
+    `;
+    var output = barista({ content: style });
+
+    it('should have the alignment modifier', function() {
+      var $o = output.$('.o-control-group--right');
+
+      assert.isOk($o.selectors.length);
+      assert.equal($o.getProp('justify-content'), 'flex-end');
+    });
+  });
+
+});

--- a/test/styles.js
+++ b/test/styles.js
@@ -1,0 +1,39 @@
+// Test :: Styles
+/* globals describe: true, it: true */
+'use strict';
+
+var assert = require('chai').assert;
+var barista = require('seed-barista');
+
+describe('seed-control-group: styles', function() {
+
+  describe('box-sizing', function() {
+    var style = `
+      @import "./_index";
+    `;
+    var output = barista({ content: style });
+
+    it('should have box-sizing: border-box reset', function() {
+      var $o = output.$('.o-control-group');
+
+      assert.equal($o.getProp('box-sizing'), 'border-box');
+    });
+  });
+
+  describe('publish', function() {
+    var style = `
+      @import "./_index";
+      @import "./_index";
+      @import "./_index";
+      @import "./_index";
+      @import "./_index";
+    `;
+    var output = barista({ content: style });
+
+    it('should only be compiled once', function() {
+      var $o = output.$('.o-control-group');
+
+      assert.equal($o.selectors.length, 1);
+    });
+  });
+});


### PR DESCRIPTION
## Updates

This adds 3 new modifiers:
* left
* center
* right

All of the above modifiers support responsive breakpoints (example: `@sm`).

Example:
```html
<div class="o-control-group o-control-group--center">...</div>
```

Adds seed-bistro and writes tests!

Resolves: https://github.com/helpscout/seed-control-group/issues/1